### PR TITLE
core: add domain aggregates, application level models (#4)

### DIFF
--- a/application/api/board_manager.go
+++ b/application/api/board_manager.go
@@ -1,14 +1,17 @@
-package application
+package api
 
 import (
+	"github.com/i1kondratiuk/kanban/application/dto"
+	"github.com/i1kondratiuk/kanban/application/model"
 	"github.com/i1kondratiuk/kanban/domain/entity"
 	"github.com/i1kondratiuk/kanban/domain/entity/common"
 	"github.com/i1kondratiuk/kanban/domain/repository"
+	"github.com/i1kondratiuk/kanban/domain/service"
 )
 
 // BoardManagerApp represents BoardManagerApp application to be called by interface layer
 type BoardManagerApp interface {
-	GetAllBoardsSortedByNameAsc() ([]*entity.Board, error)
+	GetAllBoardsSortedByNameAsc() ([]*model.Board, error)
 	Create(newBoard *entity.Board) (*entity.Board, error)
 	Update(modifiedBoard *entity.Board) (*entity.Board, error)
 	Delete(storedBoardId common.Id) error
@@ -32,31 +35,27 @@ func GetBoardManagerApp() BoardManagerApp {
 // BoardManagerAppImpl implements the KanbanBoardApp interface
 var _ BoardManagerApp = &BoardManagerAppImpl{}
 
-func (a *BoardManagerAppImpl) GetAllBoardsSortedByNameAsc() ([]*entity.Board, error) {
+func (a *BoardManagerAppImpl) GetAllBoardsSortedByNameAsc() ([]*model.Board, error) {
 	storedBoards, err := repository.GetBoardRepository().GetAllSortedByNameAsc()
 
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return storedBoards, nil
+	return dto.NewBoards(storedBoards), nil
 }
 
 func (a *BoardManagerAppImpl) Create(newBoard *entity.Board) (*entity.Board, error) {
 	insertedBoard, err := repository.GetBoardRepository().Insert(newBoard)
 
 	if err != nil {
-		return insertedBoard, err
+		return nil, err
 	}
 
-	_, err = repository.GetColumnRepository().Insert(
-		&entity.Column{
-			Board: *insertedBoard,
-		},
-	)
+	_, err = repository.GetColumnRepository().Insert(service.GetColumnService().CreateDefaultColumn(insertedBoard.Id))
 
 	if err != nil {
-		return insertedBoard, err
+		return nil, err
 	}
 
 	return insertedBoard, nil
@@ -66,7 +65,7 @@ func (a *BoardManagerAppImpl) Update(modifiedBoard *entity.Board) (*entity.Board
 	updatedBoard, err := repository.GetBoardRepository().Update(modifiedBoard)
 
 	if err != nil {
-		return updatedBoard, err
+		return nil, err
 	}
 
 	return updatedBoard, nil

--- a/application/api/comment_manager.go
+++ b/application/api/comment_manager.go
@@ -1,4 +1,4 @@
-package application
+package api
 
 import (
 	"github.com/i1kondratiuk/kanban/domain/entity"
@@ -34,7 +34,7 @@ func GetCommentManagerApp() CommentManagerApp {
 var _ CommentManagerApp = &CommentManagerAppImpl{}
 
 func (c CommentManagerAppImpl) GetAllParentCommentsGroupedByCreatedDateTime(parentId common.Id) ([]*entity.Comment, error) {
-	storedComments, err := repository.GetCommentRepository().GetGroupedByCreatedDateTimeBy(parentId)
+	storedComments, err := repository.GetCommentRepository().GetOrderedByCreatedDateTimeBy(parentId)
 
 	if err != nil {
 		return storedComments, err

--- a/application/api/coulumn_manager.go
+++ b/application/api/coulumn_manager.go
@@ -1,4 +1,4 @@
-package application
+package api
 
 import (
 	"github.com/i1kondratiuk/kanban/domain/entity"
@@ -81,7 +81,7 @@ func (a *ColumnManagerAppImpl) Delete(storedColumnId common.Id) error {
 		return err
 	}
 
-	if err := service.GetColumnService().HasColumns(parentBoardId); err != nil {
+	if err := service.GetBoardService().HasColumns(parentBoardId); err != nil {
 		return err
 	}
 

--- a/application/api/task_manager.go
+++ b/application/api/task_manager.go
@@ -1,4 +1,4 @@
-package application
+package api
 
 import (
 	"github.com/i1kondratiuk/kanban/domain/entity"
@@ -65,8 +65,8 @@ func (a *TaskManagerAppImpl) Update(columnId common.Id, newName string, newDescr
 }
 
 func (a *TaskManagerAppImpl) DeleteWithAllComments(storedTaskId common.Id) error {
-	_, err := repository.GetCommentRepository().GetGroupedByCreatedDateTimeBy(storedTaskId)
-	// err = repository.GetCommentRepository().DeleteBulk(storedComments) // TODO pluck slice of Ids
+	_, err := repository.GetCommentRepository().GetAllBy(storedTaskId)
+	// err = repository.GetCommentRepository().DeleteBulk(storedComments)
 	err = repository.GetTaskRepository().Delete(storedTaskId)
 
 	if err != nil {

--- a/application/dto/board_assembler.go
+++ b/application/dto/board_assembler.go
@@ -1,0 +1,25 @@
+package dto
+
+import (
+	"github.com/i1kondratiuk/kanban/application/model"
+	"github.com/i1kondratiuk/kanban/domain/aggregate"
+)
+
+func NewBoards(bas []*aggregate.BoardAggregate) []*model.Board {
+	var bs = make([]*model.Board, len(bas)-1)
+
+	for i, ba := range bas {
+		bs[i] = NewBoard(ba)
+	}
+
+	return bs
+}
+
+func NewBoard(ba *aggregate.BoardAggregate) *model.Board {
+	return &model.Board{
+		Id:          ba.BoardAggregateRoot.Id,
+		Name:        ba.BoardAggregateRoot.Name,
+		Description: ba.BoardAggregateRoot.Description,
+		Columns:     NewColumns(ba.ColumnAggregates),
+	}
+}

--- a/application/dto/column_assembler.go
+++ b/application/dto/column_assembler.go
@@ -1,0 +1,35 @@
+package dto
+
+import (
+	"github.com/i1kondratiuk/kanban/application/model"
+	"github.com/i1kondratiuk/kanban/domain/aggregate"
+)
+
+func NewColumns(cas []*aggregate.ColumnAggregate) []*model.Column {
+	var cs = make([]*model.Column, len(cas)-1)
+
+	for i, ca := range cas {
+		cs[i] = NewColumn(ca)
+	}
+
+	return cs
+}
+
+func NewColumn(ca *aggregate.ColumnAggregate) *model.Column {
+
+	var tasks = make([]*model.Task, len(ca.TaskEntities)-1)
+	for i, taskEntity := range tasks {
+		tasks[i] = &model.Task{
+			Id:       taskEntity.Id,
+			Name:     taskEntity.Name,
+			Position: taskEntity.Position,
+		}
+	}
+
+	return &model.Column{
+		Id:       ca.ColumnAggregateRoot.Id,
+		Name:     ca.ColumnAggregateRoot.Name,
+		Position: ca.ColumnAggregateRoot.Position,
+		Tasks:    tasks,
+	}
+}

--- a/application/dto/task_assembler.go
+++ b/application/dto/task_assembler.go
@@ -1,0 +1,37 @@
+package dto
+
+import (
+	"github.com/i1kondratiuk/kanban/application/model"
+	"github.com/i1kondratiuk/kanban/domain/aggregate"
+)
+
+func NewTasks(tas []*aggregate.TaskAggregate) []*model.Task {
+	var ts = make([]*model.Task, len(tas)-1)
+
+	for i, ta := range tas {
+		ts[i] = NewTask(ta)
+	}
+
+	return ts
+}
+
+func NewTask(ta *aggregate.TaskAggregate) *model.Task {
+
+	var comments = make([]*model.Comment, len(ta.Comments)-1)
+	for i, comment := range ta.Comments {
+		comments[i] = &model.Comment{
+			Id:              comment.Id,
+			CreatedDateTime: comment.CreatedDateTime,
+			Comment:         comment.Comment,
+		}
+	}
+
+	return &model.Task{
+		Id:          ta.Id,
+		Name:        ta.Name,
+		Description: ta.Description,
+		Priority:    ta.Priority,
+		Position:    ta.Position,
+		Comments:    comments,
+	}
+}

--- a/application/model/board.go
+++ b/application/model/board.go
@@ -1,0 +1,13 @@
+package model
+
+import (
+	"github.com/i1kondratiuk/kanban/domain/entity/common"
+)
+
+// Board represents the board entity stored in repository
+type Board struct {
+	Id          common.Id `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	Columns     []*Column `json:"columns"`
+}

--- a/application/model/column.go
+++ b/application/model/column.go
@@ -1,0 +1,11 @@
+package model
+
+import "github.com/i1kondratiuk/kanban/domain/entity/common"
+
+// Column represents the column entity stored in repository
+type Column struct {
+	Id       common.Id `json:"id"`
+	Name     string    `json:"name"`
+	Position int       `json:"position"`
+	Tasks    []*Task   `json:"tasks"`
+}

--- a/application/model/comment.go
+++ b/application/model/comment.go
@@ -1,0 +1,13 @@
+package model
+
+import (
+	"github.com/i1kondratiuk/kanban/domain/entity/common"
+	"github.com/i1kondratiuk/kanban/domain/value"
+)
+
+// Comment represents a comment
+type Comment struct {
+	Id              common.Id              `json:"id"`
+	CreatedDateTime common.CreatedDateTime `json:"createdDateTime"`
+	Comment         value.Comment          `json:"comment"`
+}

--- a/application/model/task.go
+++ b/application/model/task.go
@@ -1,0 +1,15 @@
+package model
+
+import (
+	"github.com/i1kondratiuk/kanban/domain/entity/common"
+)
+
+// Task represents the task entity stored in repository
+type Task struct {
+	Id          common.Id  `json:"id"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	Priority    int        `json:"priority"`
+	Position    int        `json:"position"`
+	Comments    []*Comment `json:"comments"`
+}

--- a/domain/aggregate/board.go
+++ b/domain/aggregate/board.go
@@ -1,0 +1,33 @@
+package aggregate
+
+import (
+	"github.com/i1kondratiuk/kanban/domain/entity"
+)
+
+// BoardAggregate represents the board entity as the aggregate root with Columns (its related child entities)
+type BoardAggregate struct {
+	BoardAggregateRoot *entity.Board
+	ColumnAggregates   []*ColumnAggregate
+}
+
+// NewBoard creates a new Board Aggregate instance
+func (ba *BoardAggregate) NewBoard(b *entity.Board, cs []*ColumnAggregate) *BoardAggregate {
+	return &BoardAggregate{
+		BoardAggregateRoot: b,
+		ColumnAggregates:   cs,
+	}
+}
+
+// Column represents the column entity as the aggregate root with Tasks (its related child entities)
+type ColumnAggregate struct {
+	ColumnAggregateRoot *entity.Column
+	TaskEntities        []*entity.Task
+}
+
+// NewBColumn creates a new Column Aggregate instance
+func (ca *ColumnAggregate) NewColumn(c *entity.Column, ts []*entity.Task) *ColumnAggregate {
+	return &ColumnAggregate{
+		ColumnAggregateRoot: c,
+		TaskEntities:        ts,
+	}
+}

--- a/domain/aggregate/task.go
+++ b/domain/aggregate/task.go
@@ -1,0 +1,17 @@
+package aggregate
+
+import (
+	"github.com/i1kondratiuk/kanban/domain/entity"
+	"github.com/i1kondratiuk/kanban/domain/entity/common"
+)
+
+// TaskAggregate represents the task entity as the aggregate root with Comments (its related child entities)
+type TaskAggregate struct {
+	Id          common.Id        `json:"id"`
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	Priority    int              `json:"priority"`
+	Position    int              `json:"position"`
+	Column      entity.Column    `json:"column"`
+	Comments    []entity.Comment `json:"comments"`
+}

--- a/domain/entity/board.go
+++ b/domain/entity/board.go
@@ -4,8 +4,7 @@ import "github.com/i1kondratiuk/kanban/domain/entity/common"
 
 // Board represents the board entity stored in repository
 type Board struct {
-	Id          common.Id `json:"id"`
-	Name        string    `json:"name"`
-	Description string    `json:"description"`
-	Columns     []Column  `json:"columns"`
+	Id          common.Id
+	Name        string
+	Description string
 }

--- a/domain/entity/column.go
+++ b/domain/entity/column.go
@@ -4,9 +4,8 @@ import "github.com/i1kondratiuk/kanban/domain/entity/common"
 
 // Column represents the column entity stored in repository
 type Column struct {
-	Id       common.Id `json:"id"`
-	Name     string    `json:"name"`
-	Position int       `json:"position"`
-	Board    Board     `json:"board"`
-	Tasks    []Task    `json:"tasks"`
+	Id       common.Id
+	Name     string
+	Position int
+	Board    Board
 }

--- a/domain/entity/comment.go
+++ b/domain/entity/comment.go
@@ -7,7 +7,7 @@ import (
 
 // Comment represents a comment
 type Comment struct {
-	Id              common.Id              `json:"id"`
-	CreatedDateTime common.CreatedDateTime `json:"createdDateTime"`
-	Comment         value.Comment          `json:"comment"`
+	Id              common.Id
+	CreatedDateTime common.CreatedDateTime
+	Comment         value.Comment
 }

--- a/domain/entity/task.go
+++ b/domain/entity/task.go
@@ -4,10 +4,10 @@ import "github.com/i1kondratiuk/kanban/domain/entity/common"
 
 // Task represents the task entity stored in repository
 type Task struct {
-	Id          common.Id `json:"id"`
-	Name        string    `json:"name"`
-	Description string    `json:"description"`
-	Priority    int       `json:"priority"`
-	Position    int       `json:"position"`
-	Column      Column    `json:"column"`
+	Id          common.Id
+	Name        string
+	Description string
+	Priority    int
+	Position    int
+	Column      Column
 }

--- a/domain/repository/board_repository.go
+++ b/domain/repository/board_repository.go
@@ -1,13 +1,14 @@
 package repository
 
 import (
+	"github.com/i1kondratiuk/kanban/domain/aggregate"
 	"github.com/i1kondratiuk/kanban/domain/entity"
 	"github.com/i1kondratiuk/kanban/domain/entity/common"
 )
 
 // BoardRepository represents a storage of all existing boards
 type BoardRepository interface {
-	GetAllSortedByNameAsc() ([]*entity.Board, error)
+	GetAllSortedByNameAsc() ([]*aggregate.BoardAggregate, error)
 	Insert(newBoard *entity.Board) (*entity.Board, error)
 	Update(modifiedBoard *entity.Board) (*entity.Board, error)
 	Delete(storedBoardId common.Id) error

--- a/domain/repository/column_repository.go
+++ b/domain/repository/column_repository.go
@@ -8,6 +8,8 @@ import (
 // ColumnRepository represents a storage of all existing columns
 type ColumnRepository interface {
 	GetAllWithRelatedTasksBy(parentBoardId common.Id) ([]*entity.Column, error)
+	GetByChildTaskId(taskId common.Id) (entity.Column, error)
+	GetByParentBoardIdAndPosition(parentBoardId common.Id, position int) (*entity.Column, error)
 	GetBoardId(columnId common.Id) (parentBoardId common.Id, err error)
 	CountAllBy(parentBoardId common.Id) (int, error)
 	Insert(newColumn *entity.Column) (*entity.Column, error)

--- a/domain/repository/comment_repository.go
+++ b/domain/repository/comment_repository.go
@@ -8,7 +8,7 @@ import (
 
 // CommentRepository represents a storage of all existing comments
 type CommentRepository interface {
-	GetGroupedByCreatedDateTimeBy(parentId common.Id) ([]*entity.Comment, error)
+	GetOrderedByCreatedDateTimeBy(parentId common.Id) ([]*entity.Comment, error)
 	GetAllBy(parentId common.Id) ([]*entity.Comment, error)
 	Insert(newComment *entity.Comment) (*entity.Comment, error)
 	Update(storedCommentId common.Id, newBodyText value.BodyText) (*entity.Comment, error)

--- a/domain/service/board_service.go
+++ b/domain/service/board_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+
 	"github.com/i1kondratiuk/kanban/domain/entity/common"
 	"github.com/i1kondratiuk/kanban/domain/repository"
 )
@@ -16,8 +17,8 @@ type BoardServiceImpl struct{}
 
 var boardService BoardService
 
-// GetColumnService returns a BoardService
-func GetColumnService() BoardService {
+// GetBoardService returns a BoardService
+func GetBoardService() BoardService {
 	return boardService
 }
 

--- a/domain/service/column_service.go
+++ b/domain/service/column_service.go
@@ -1,0 +1,36 @@
+package service
+
+import (
+	"github.com/i1kondratiuk/kanban/domain/entity"
+	"github.com/i1kondratiuk/kanban/domain/entity/common"
+)
+
+const defaultColumnName = "Default"
+
+// ColumnService represents the service to handle business rules related to Kanban Boards' Columns
+type ColumnService interface {
+	CreateDefaultColumn(parentBoardId common.Id) *entity.Column
+}
+
+// ColumnServiceImpl is the implementation of ColumnService
+type ColumnServiceImpl struct{}
+
+var columnService ColumnService
+
+// GetColumnService returns a ColumnService
+func GetColumnService() ColumnService {
+	return columnService
+}
+
+// InitColumnService injects ColumnService with its implementation
+func InitColumnService(a ColumnService) {
+	columnService = a
+}
+
+// Creates default Column with parent Board assigned
+func (a *ColumnServiceImpl) CreateDefaultColumn(parentBoardId common.Id) *entity.Column {
+	return &entity.Column{
+		Board: entity.Board{Id: parentBoardId},
+		Name:  defaultColumnName,
+	}
+}

--- a/interface/web/webjson/handler/boards.go
+++ b/interface/web/webjson/handler/boards.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/i1kondratiuk/kanban/application"
+	"github.com/i1kondratiuk/kanban/application/api"
 )
 
 // BoardManagerAppHandler ...
 type BoardManagerAppHandler struct {
-	BoardManagerApp application.BoardManagerApp
+	BoardManagerApp api.BoardManagerApp
 }
 
 // AddRoutes adds BoardManagerAppHandler routs

--- a/interface/web/webjson/handler/columns.go
+++ b/interface/web/webjson/handler/columns.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/i1kondratiuk/kanban/application"
+	"github.com/i1kondratiuk/kanban/application/api"
 )
 
 // ColumnManagerAppHandler handler
 type ColumnManagerAppHandler struct {
-	ColumnManagerApp application.ColumnManagerApp
+	ColumnManagerApp api.ColumnManagerApp
 }
 
 // AddRoutes adds ColumnManagerAppHandler routs

--- a/interface/web/webjson/handler/comments.go
+++ b/interface/web/webjson/handler/comments.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/i1kondratiuk/kanban/application"
+	"github.com/i1kondratiuk/kanban/application/api"
 )
 
 // CommentManagerAppHandler handler
 type CommentManagerAppHandler struct {
-	CommentManagerApp application.CommentManagerApp
+	CommentManagerApp api.CommentManagerApp
 }
 
 // AddRoutes adds CommentManagerAppHandler routs

--- a/interface/web/webjson/handler/tasks.go
+++ b/interface/web/webjson/handler/tasks.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/i1kondratiuk/kanban/application"
+	"github.com/i1kondratiuk/kanban/application/api"
 )
 
 // TaskManagerAppHandler handler
 type TaskManagerAppHandler struct {
-	TaskManagerApp application.TaskManagerApp
+	TaskManagerApp api.TaskManagerApp
 }
 
 // AddRoutes adds TaskManagerAppHandler routs

--- a/interface/web/webjson/model/board.go
+++ b/interface/web/webjson/model/board.go
@@ -1,0 +1,10 @@
+package entity
+
+import (
+	"github.com/i1kondratiuk/kanban/application/model"
+)
+
+// Board represents the model to be shown to the API client
+type Board struct {
+	model.Board
+}

--- a/interface/web/webjson/model/column.go
+++ b/interface/web/webjson/model/column.go
@@ -1,0 +1,10 @@
+package entity
+
+import (
+	"github.com/i1kondratiuk/kanban/application/model"
+)
+
+// Column represents the model to be shown to the API client
+type Column struct {
+	model.Column
+}

--- a/interface/web/webjson/model/comment.go
+++ b/interface/web/webjson/model/comment.go
@@ -1,0 +1,10 @@
+package entity
+
+import (
+	"github.com/i1kondratiuk/kanban/application/model"
+)
+
+// Comment represents the model exposed to the API client
+type Comment struct {
+	model.Comment
+}

--- a/interface/web/webjson/model/task.go
+++ b/interface/web/webjson/model/task.go
@@ -1,0 +1,10 @@
+package entity
+
+import (
+	"github.com/i1kondratiuk/kanban/application/model"
+)
+
+// Task represents the model exposed to the API client
+type Task struct {
+	model.Task
+}

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/i1kondratiuk/kanban/application"
+	"github.com/i1kondratiuk/kanban/application/api"
 	"github.com/i1kondratiuk/kanban/config"
 	"github.com/i1kondratiuk/kanban/domain/repository"
 	"github.com/i1kondratiuk/kanban/infrastructure/persistence"
@@ -44,10 +44,10 @@ func init() {
 }
 
 func main() {
-	application.InitBoardManagerApp(&application.BoardManagerAppImpl{})
-	application.InitColumnManagerApp(&application.ColumnManagerAppImpl{})
-	application.InitCommentManagerApp(&application.CommentManagerAppImpl{})
-	application.InitTaskManagerApp(&application.TaskManagerAppImpl{})
+	api.InitBoardManagerApp(&api.BoardManagerAppImpl{})
+	api.InitColumnManagerApp(&api.ColumnManagerAppImpl{})
+	api.InitCommentManagerApp(&api.CommentManagerAppImpl{})
+	api.InitTaskManagerApp(&api.TaskManagerAppImpl{})
 
 	handler.Run(8080)
 }


### PR DESCRIPTION
* move default column creation to a separate service

* return errors to handlers

* fix(compile-failure): use correct service

* add models with dto assemblers to the application layer

* replace domain layer entities references with application layer models

* add domain aggregates

* add webjson json interface models

* rename the application package to api

* replace application package usages with api in main

Co-authored-by: Ivan Kondratiuk <ivan.kondratiuk@bp.com>